### PR TITLE
Add REST API and reliability upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Agents should always update the relevant state files when planning or completing
 
 ### Setup
 1. Run `./bootstrap.sh` to install PowerShell, Cloudflared and Git.
-2. Clone the optional helper tools with `./clone_agent_suite.sh`.
+2. Install the REST server dependency with `pip install flask`.
+3. Clone the optional helper tools with `./clone_agent_suite.sh`.
 
 ### Starting the Cloudflare Tunnel
 1. Place your Cloudflare credentials at `/etc/cloudflared/credentials.json`.
@@ -76,10 +77,20 @@ Use `multi_host_support.sh` to register and list host tags:
 ### Executing Commands
 
 ```bash
-./exec_remote.sh qa1 "Get-Service Spooler"
+./exec_remote.sh "qa1 qa2" "Get-Service Spooler"
 ```
 
-The result is printed as JSON containing `exitCode` and `stdout`.
+The result is printed as JSON. When multiple hosts are specified, an array of per-host objects is returned.
+
+### REST API
+Start the REST server with `python3 agent_exec.py` or via `watchdog.sh`. Example usage:
+
+```bash
+curl -X POST http://localhost:5000/exec -H "Content-Type: application/json" \
+  -d '{"target": "qa1", "cmd": "Get-Service Spooler"}'
+```
+
+Other endpoints follow the same pattern: `/send_file`, `/get_file`, `/sync_dir`. Use `GET /hosts` to list known hosts and `GET /health` for status.
 
 ### File Transfer
 

--- a/agent_exec.py
+++ b/agent_exec.py
@@ -1,0 +1,78 @@
+import subprocess
+import json
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+
+def run_cmd(cmd_list):
+    result = subprocess.run(cmd_list, capture_output=True, text=True)
+    out = result.stdout.strip()
+    err = result.stderr.strip()
+    code = result.returncode
+    return {"stdout": out, "stderr": err, "exitCode": code}
+
+@app.post('/exec')
+def exec_cmd():
+    data = request.get_json(force=True)
+    target = data.get('target')
+    cmd = data.get('cmd')
+    if not target or not cmd:
+        return jsonify({'error': 'target and cmd required'}), 400
+    res = run_cmd(['./exec_remote.sh', target, cmd])
+    try:
+        payload = json.loads(res['stdout'])
+        res.update(payload)
+    except Exception:
+        pass
+    return jsonify(res)
+
+@app.post('/send_file')
+def send_file():
+    data = request.get_json(force=True)
+    target = data.get('target')
+    local_path = data.get('local_path')
+    remote_path = data.get('remote_path')
+    if not target or not local_path or not remote_path:
+        return jsonify({'error': 'target, local_path, remote_path required'}), 400
+    res = run_cmd(['./send_file.sh', target, local_path, remote_path])
+    return jsonify(res)
+
+@app.post('/get_file')
+def get_file():
+    data = request.get_json(force=True)
+    target = data.get('target')
+    remote_path = data.get('remote_path')
+    local_path = data.get('local_path')
+    if not target or not remote_path or not local_path:
+        return jsonify({'error': 'target, remote_path, local_path required'}), 400
+    res = run_cmd(['./get_file.sh', target, remote_path, local_path])
+    return jsonify(res)
+
+@app.post('/sync_dir')
+def sync_dir():
+    data = request.get_json(force=True)
+    target = data.get('target')
+    local_dir = data.get('local_dir')
+    remote_dir = data.get('remote_dir')
+    if not target or not local_dir or not remote_dir:
+        return jsonify({'error': 'target, local_dir, remote_dir required'}), 400
+    res = run_cmd(['./sync_dir.sh', target, local_dir, remote_dir])
+    return jsonify(res)
+
+@app.get('/hosts')
+def hosts():
+    try:
+        with open('hosts.db') as f:
+            lines = [l.strip() for l in f if l.strip()]
+    except FileNotFoundError:
+        lines = []
+    return jsonify({'hosts': lines})
+
+@app.get('/health')
+def health():
+    res = run_cmd(['./health_endpoint.sh'])
+    return jsonify(res)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/agent_prio.md
+++ b/agent_prio.md
@@ -139,3 +139,51 @@
   priority: 4
   status: [x]
 ---
+- uuid: 29a25464-c91d-4aa6-a715-4ab6e26c5cc1
+  parent: f7eafc2c-7724-4616-8790-4f1ca8ce6b2c
+  description: Implement agent_exec.py REST API server
+  why: Provide HTTP interface to remote execution and file management
+  depends_on: [63675cf5-30d6-4891-a12a-61042475ad85]
+  priority: 5
+  status: []
+---
+- uuid: bb044495-f26d-47d5-bc58-a30612fad872
+  parent: f7eafc2c-7724-4616-8790-4f1ca8ce6b2c
+  description: Extend session_manager.ps1 with auto-reconnect and logging
+  why: Maintain live sessions and record status
+  depends_on: [29a25464-c91d-4aa6-a715-4ab6e26c5cc1]
+  priority: 5
+  status: []
+---
+- uuid: 4635180e-1e7e-4443-8f17-5056334d9597
+  parent: f7eafc2c-7724-4616-8790-4f1ca8ce6b2c
+  description: Add parallel execution to exec_remote.sh with JSON aggregation
+  why: Run commands concurrently across multiple targets
+  depends_on: [bb044495-f26d-47d5-bc58-a30612fad872]
+  priority: 5
+  status: []
+---
+- uuid: 70206be2-c6ee-4ef7-bfbd-31e322524e64
+  parent: f7eafc2c-7724-4616-8790-4f1ca8ce6b2c
+  description: Integrate failed command handling with agent_prio and auto_diagnose
+  why: Escalate issues and attempt automated recovery
+  depends_on: [4635180e-1e7e-4443-8f17-5056334d9597]
+  priority: 5
+  status: []
+---
+- uuid: 6a6fe28d-00cd-462d-a4df-8facf46c2467
+  parent: f7eafc2c-7724-4616-8790-4f1ca8ce6b2c
+  description: Add watchdog recovery and 60s session heartbeats
+  why: Keep REST API and tunnel running reliably
+  depends_on: [70206be2-c6ee-4ef7-bfbd-31e322524e64]
+  priority: 5
+  status: []
+---
+- uuid: 4cc3a4e9-3b46-4ab8-aca3-9eb045ded7c4
+  parent: f7eafc2c-7724-4616-8790-4f1ca8ce6b2c
+  description: Update documentation and diagrams for REST API usage
+  why: Help users adopt new capabilities
+  depends_on: [6a6fe28d-00cd-462d-a4df-8facf46c2467]
+  priority: 5
+  status: []
+---

--- a/agent_tasks.md
+++ b/agent_tasks.md
@@ -59,3 +59,10 @@
   priority: 4
   status: [x]
 ---
+- uuid: f7eafc2c-7724-4616-8790-4f1ca8ce6b2c
+  description: Expand BshToPwsh into REST API with reliability features
+  why: Provide multi-node agent orchestration via HTTP
+  depends_on: [3612f089-abdc-49f1-877d-1ee46c146d59]
+  priority: 5
+  status: []
+---

--- a/auto_diagnose.sh
+++ b/auto_diagnose.sh
@@ -1,7 +1,21 @@
 #!/bin/bash
-# Placeholder for auto-diagnosis using ChatGPT API
-# Task UUID: 63675cf5-30d6-4891-a12a-61042475ad85
+# Attempt automatic recovery on failure
+# Task UUID: 63675cf5-30d6-4891-a12a-61042475ad85 / 70206be2-c6ee-4ef7-bfbd-31e322524e64
 set -euo pipefail
 
-echo "Auto-diagnosis not implemented in offline mode" >&2
-exit 0
+TARGET="$1"
+CMD="$2"
+
+for i in {1..3}; do
+  ./tunnel_setup.sh || true
+  pwsh -File session_manager.ps1 -Target "$TARGET" || true
+  RESULT=$(ssh "$TARGET" "powershell -NoProfile -Command \"$CMD | ConvertTo-Json -Depth 3\"" 2>&1)
+  EC=$?
+  if [ $EC -eq 0 ]; then
+    echo "$RESULT"
+    exit 0
+  fi
+  sleep 1
+done
+printf 'Recovery failed after 3 attempts\n' >&2
+exit 1

--- a/exec_remote.sh
+++ b/exec_remote.sh
@@ -1,19 +1,39 @@
 #!/bin/bash
-# Execute a PowerShell command on the remote host and return JSON
-# Task UUID: b7ae2b8c-fb9a-4bf9-b871-4d97b7eddbcf
+# Execute PowerShell commands on one or more remote hosts with JSON output
+# Task UUID: b7ae2b8c-fb9a-4bf9-b871-4d97b7eddbcf / 4635180e-1e7e-4443-8f17-5056334d9597
 set -euo pipefail
 
-TARGET="$1"
-COMMAND="$2"
+TARGETS=($1)
+CMD="$2"
 
-pwsh -File session_manager.ps1 -Target "$TARGET"
+TMPDIR=$(mktemp -d)
 
-OUTPUT=$(ssh "$TARGET" "powershell -NoProfile -Command \"$COMMAND | ConvertTo-Json -Depth 3\"" 2>&1)
-EXIT_CODE=$?
+for T in ${TARGETS[@]}; do
+  (
+    pwsh -File session_manager.ps1 -Target "$T"
+    OUTPUT=$(ssh "$T" "powershell -NoProfile -Command \"$CMD | ConvertTo-Json -Depth 3\"" 2>&1)
+    EC=$?
+    printf '{"target":"%s","exitCode":%s,"stdout":"%s"}' "$T" "$EC" "${OUTPUT//$'\n'/ }" > "$TMPDIR/$T.json"
+    if [ $EC -ne 0 ]; then
+      sed -i 's/status: \[x\]/status: [u]/' agent_prio.md
+      ./auto_diagnose.sh "$T" "$CMD" || true
+    fi
+  ) &
+  PIDS+="$! "
+done
+wait $PIDS
 
-cat <<JSON
-{
-  "exitCode": $EXIT_CODE,
-  "stdout": "$OUTPUT"
-}
-JSON
+FILES=($TMPDIR/*.json)
+if [ ${#FILES[@]} -eq 1 ]; then
+  cat "${FILES[0]}"
+else
+  echo '['
+  FIRST=1
+  for F in "${FILES[@]}"; do
+    if [ $FIRST -eq 0 ]; then echo ','; fi
+    cat "$F"
+    FIRST=0
+  done
+  echo ']'
+fi
+rm -rf "$TMPDIR"

--- a/manifest.json
+++ b/manifest.json
@@ -55,6 +55,18 @@
       "files": [
         "README.md"
       ]
+    },
+    {
+      "uuid": "f7eafc2c-7724-4616-8790-4f1ca8ce6b2c",
+      "files": [
+        "agent_exec.py",
+        "session_manager.ps1",
+        "exec_remote.sh",
+        "auto_diagnose.sh",
+        "watchdog.sh",
+        "taskmap.svg",
+        "README.md"
+      ]
     }
   ]
 }

--- a/session_manager.ps1
+++ b/session_manager.ps1
@@ -1,21 +1,53 @@
-# Establish persistent PowerShell sessions to remote targets
-# Task UUID: c89cc60d-6f6b-46bb-94d7-db15d60a4779
+# Establish persistent PowerShell sessions to remote targets with auto-recovery
+# Task UUID: c89cc60d-6f6b-46bb-94d7-db15d60a4779 / bb044495-f26d-47d5-bc58-a30612fad872
 param(
     [string]$Target,
     [string]$CredentialFile = "$HOME/.config/bsh2pwsh/cred.xml"
 )
+
+$logPath = "logs/sessions.log"
+$sessionFile = "$HOME/.config/bsh2pwsh/$Target.session"
+
+function Log($msg) {
+    $timestamp = (Get-Date).ToString('o')
+    "$timestamp $msg" | Out-File -FilePath $logPath -Append
+}
 
 if (-not (Test-Path $CredentialFile)) {
     throw "Credential file not found: $CredentialFile"
 }
 
 $cred = Import-Clixml -Path $CredentialFile
+$session = $null
 
+if (Test-Path $sessionFile) {
+    try {
+        $session = Import-Clixml -Path $sessionFile
+        if (-not (Test-PSSession -Session $session)) {
+            Remove-PSSession -Session $session -ErrorAction SilentlyContinue
+            $session = $null
+        }
+    } catch {
+        $session = $null
+    }
+}
+
+if (-not $session) {
+    try {
+        $session = New-PSSession -ComputerName $Target -Credential $cred
+        $session | Export-Clixml -Path $sessionFile
+        Log "Re-established session to $Target"
+    } catch {
+        Log "Failed to establish session to $Target: $_"
+        exit 1
+    }
+} else {
+    Log "Session active to $Target"
+}
+
+# Heartbeat update
 try {
-    $session = New-PSSession -ComputerName $Target -Credential $cred
-    Write-Host "Session established to $Target"
-    $session | Export-Clixml -Path "$HOME/.config/bsh2pwsh/$Target.session"
+    Invoke-Command -Session $session -ScriptBlock { 'pong' } | Out-Null
 } catch {
-    Write-Error "Failed to establish session: $_"
-    exit 1
+    Log "Heartbeat failed for $Target"
 }

--- a/state.md
+++ b/state.md
@@ -1,5 +1,5 @@
 # Planner State
 
-graph_hash: b25cfad5384ba22015867ce4bd2198a4766b5770
-last_task: 3612f089-abdc-49f1-877d-1ee46c146d59
+graph_hash: 03f86680b9f5347f923794df4893f0800a77531e
+last_task: f7eafc2c-7724-4616-8790-4f1ca8ce6b2c
 active_agents:

--- a/taskmap.svg
+++ b/taskmap.svg
@@ -1,2 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="140"><text x="10" y="15">1. BOOTSTRAP</text><text x="200" y="15">d358226d-c11e-4dc4-a700-4657916e3658</text><text x="10" y="35">2. TUNNELS</text><text x="200" y="35">3007c5ed-3db3-4b87-a16e-f07ac23e65ef</text><text x="10" y="55">3. REMOTE_EXEC</text><text x="200" y="55">49fbdceb-36e6-43e0-b4f9-2a153ba5d50d</text><text x="10" y="75">4. FILE_TRANSFER</text><text x="200" y="75">f4e859b6-267c-4e9e-9116-cae33f5e6562</text><text x="10" y="95">5. WATCHDOG</text><text x="200" y="95">28a04f9c-de1c-44fd-9071-372f998d4d7e</text><text x="10" y="115">6. MULTI_HOST</text><text x="200" y="115">136085ab-8611-4003-bb9a-b12927505c67</text><text x="10" y="135">7. DOCS</text><text x="200" y="135">3612f089-abdc-49f1-877d-1ee46c146d59</text></svg>
-
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="160">
+<text x="10" y="15">1. BOOTSTRAP</text><text x="200" y="15">d358226d-c11e-4dc4-a700-4657916e3658</text>
+<text x="10" y="35">2. TUNNELS</text><text x="200" y="35">3007c5ed-3db3-4b87-a16e-f07ac23e65ef</text>
+<text x="10" y="55">3. REMOTE_EXEC</text><text x="200" y="55">49fbdceb-36e6-43e0-b4f9-2a153ba5d50d</text>
+<text x="10" y="75">4. FILE_TRANSFER</text><text x="200" y="75">f4e859b6-267c-4e9e-9116-cae33f5e6562</text>
+<text x="10" y="95">5. WATCHDOG</text><text x="200" y="95">28a04f9c-de1c-44fd-9071-372f998d4d7e</text>
+<text x="10" y="115">6. MULTI_HOST</text><text x="200" y="115">136085ab-8611-4003-bb9a-b12927505c67</text>
+<text x="10" y="135">7. DOCS</text><text x="200" y="135">3612f089-abdc-49f1-877d-1ee46c146d59</text>
+<text x="10" y="155">8. REST_API</text><text x="200" y="155">f7eafc2c-7724-4616-8790-4f1ca8ce6b2c</text>
+</svg>

--- a/tests/test_agent_exec_exists.py
+++ b/tests/test_agent_exec_exists.py
@@ -1,0 +1,5 @@
+import os
+
+
+def test_agent_exec_exists():
+    assert os.path.isfile('agent_exec.py')

--- a/tests/test_exec_remote_parallel.py
+++ b/tests/test_exec_remote_parallel.py
@@ -1,0 +1,7 @@
+import os
+
+
+def test_exec_remote_parallel_contains_wait():
+    with open('exec_remote.sh') as f:
+        content = f.read()
+    assert 'wait' in content

--- a/watchdog.sh
+++ b/watchdog.sh
@@ -1,11 +1,25 @@
 #!/bin/bash
-# Restart tunnels and sessions if disconnected
-# Task UUID: b0dbc675-0b7a-4268-88f8-a96adcda65aa
+# Restart tunnels and REST API if disconnected and send session heartbeats
+# Task UUID: b0dbc675-0b7a-4268-88f8-a96adcda65aa / 6a6fe28d-00cd-462d-a4df-8facf46c2467
 set -euo pipefail
+
+API_PID_FILE="agent_api.pid"
+
+function start_api {
+    if [ ! -f "$API_PID_FILE" ] || ! kill -0 $(cat "$API_PID_FILE") 2>/dev/null; then
+        nohup python3 agent_exec.py >/dev/null 2>&1 & echo $! > "$API_PID_FILE"
+    fi
+}
 
 while true; do
     if ! pgrep -f "cloudflared tunnel" >/dev/null; then
         ./tunnel_setup.sh
     fi
-    sleep 5
+    start_api
+    for sess in $HOME/.config/bsh2pwsh/*.session; do
+        [ -e "$sess" ] || continue
+        target=$(basename "$sess" .session)
+        pwsh -File session_manager.ps1 -Target "$target" >/dev/null 2>&1 || true
+    done
+    sleep 60
 done


### PR DESCRIPTION
## Summary
- implement `agent_exec.py` Flask server for exec and file transfer APIs
- enhance session management with auto-reconnect and heartbeat logging
- allow `exec_remote.sh` to run commands on multiple hosts concurrently
- add automatic recovery routine and improved watchdog
- document REST API and parallel execution syntax
- track new tasks and update DAG files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68893de6305c832e87df9f4f27c7c16c